### PR TITLE
using rsample instead of broom for speed and fixing some warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tidyboot
 Type: Package
 Title: Tidyverse-Compatible Bootstrapping
-Version: 0.1.1.9001
+Version: 0.1.1.9002
 Authors@R: c(
     person("Mika", "Braginsky", email = "mika.br@gmail.com", role = c("aut", "cre")),
     person("Daniel", "Yurovsky", email = "dyurovsky@gmail.com", role = c("aut"))
@@ -14,10 +14,11 @@ URL: https://github.com/langcog/tidyboot
 BugReports: http://github.com/langcog/tidyboot/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.1
-Imports: 
+RoxygenNote: 7.0.2
+Imports:
   dplyr (>= 0.7.4),
   modelr (>= 0.1.1),
   purrr (>= 0.2.4),
   rlang (>= 0.1.6),
-  tidyr (>= 0.7.2)
+  tidyr (>= 0.7.2),
+  rsample (>= 0.0.6)

--- a/man/tidyboot.data.frame.Rd
+++ b/man/tidyboot.data.frame.Rd
@@ -4,8 +4,14 @@
 \alias{tidyboot.data.frame}
 \title{Non-parametric bootstrap for data frames}
 \usage{
-\method{tidyboot}{data.frame}(data, column = NULL,
-  summary_function = mean, statistics_functions, nboot = 1000, ...)
+\method{tidyboot}{data.frame}(
+  data,
+  column = NULL,
+  summary_function = mean,
+  statistics_functions,
+  nboot = 1000,
+  ...
+)
 }
 \arguments{
 \item{data}{A data frame.}

--- a/man/tidyboot.logical.Rd
+++ b/man/tidyboot.logical.Rd
@@ -4,8 +4,15 @@
 \alias{tidyboot.logical}
 \title{Non-parametric bootstrap for logical vector data}
 \usage{
-\method{tidyboot}{logical}(data, summary_function = mean,
-  statistics_functions, nboot = 1000, size = 1, replace = TRUE, ...)
+\method{tidyboot}{logical}(
+  data,
+  summary_function = mean,
+  statistics_functions,
+  nboot = 1000,
+  size = 1,
+  replace = TRUE,
+  ...
+)
 }
 \arguments{
 \item{data}{A logical vector of data to bootstrap over.}

--- a/man/tidyboot.numeric.Rd
+++ b/man/tidyboot.numeric.Rd
@@ -4,8 +4,15 @@
 \alias{tidyboot.numeric}
 \title{Non-parametric bootstrap for numeric vector data}
 \usage{
-\method{tidyboot}{numeric}(data, summary_function = mean,
-  statistics_functions, nboot = 1000, size = 1, replace = TRUE, ...)
+\method{tidyboot}{numeric}(
+  data,
+  summary_function = mean,
+  statistics_functions,
+  nboot = 1000,
+  size = 1,
+  replace = TRUE,
+  ...
+)
 }
 \arguments{
 \item{data}{A numeric vector of data to bootstrap over.}


### PR DESCRIPTION
runs a little faster than the old version and doesn't warn you about unnest etc.

Also i took the bootstrapped mean out of tidyboot_mean because i don't think anyone wants that