### PR TITLE
switch to unnest_legacy (#8 #9)

### DIFF
--- a/R/tidyboot.R
+++ b/R/tidyboot.R
@@ -156,7 +156,7 @@ tidyboot.data.frame <- function(data,
 
   samples <- data %>%
     modelr::bootstrap(n = nboot) %>%
-    dplyr::mutate(strap = purrr::map(strap, dplyr::as_data_frame)) %>%
+    dplyr::mutate(strap = purrr::map(strap, dplyr::as_tibble)) %>%
     tidyr::unnest_legacy()
 
   if (!rlang::is_null(data_groups)) {

--- a/R/tidyboot.R
+++ b/R/tidyboot.R
@@ -157,7 +157,7 @@ tidyboot.data.frame <- function(data,
   samples <- data %>%
     modelr::bootstrap(n = nboot) %>%
     dplyr::mutate(strap = purrr::map(strap, dplyr::as_data_frame)) %>%
-    tidyr::unnest()
+    tidyr::unnest_legacy()
 
   if (!rlang::is_null(data_groups)) {
     samples <- samples %>% dplyr::group_by(!!!data_groups, .id)

--- a/inst/tidyboot_testing.R
+++ b/inst/tidyboot_testing.R
@@ -34,7 +34,7 @@ modelr_boot <- function(df, nboot = 1000) {
   booted <- df %>%
     modelr::bootstrap(nboot) %>%
     mutate(strap = map(strap, as_data_frame)) %>%
-    unnest()
+    unnest_legacy()
 
   booted %>%
     group_by(.id, condition) %>%

--- a/inst/tidyboot_testing.R
+++ b/inst/tidyboot_testing.R
@@ -16,7 +16,7 @@ modelr_boot <- function(df, nboot = 1000) {
     modelr::bootstrap(nboot)
 
   booted$strap %>%
-    map_df(~.x %>% as_data_frame() %>%
+    map_df(~.x %>% as_tibble() %>%
              group_by(condition) %>%
              summarise(stat = mean(value, na.rm = FALSE))) %>%
     group_by(condition) %>%
@@ -33,7 +33,7 @@ system.time(
 modelr_boot <- function(df, nboot = 1000) {
   booted <- df %>%
     modelr::bootstrap(nboot) %>%
-    mutate(strap = map(strap, as_data_frame)) %>%
+    mutate(strap = map(strap, as_tibble)) %>%
     unnest_legacy()
 
   booted %>%
@@ -58,7 +58,7 @@ modelr_boot_na.rm <- function(df, nboot = 1000, na.rm = FALSE) {
     modelr::bootstrap(nboot)
 
   booted$strap %>%
-    map_df(~.x %>% as_data_frame() %>%
+    map_df(~.x %>% as_tibble() %>%
              group_by(condition) %>%
              summarise(stat = mean(value, na.rm = na.rm))) %>%
     group_by(condition) %>%


### PR DESCRIPTION
This addresses the performance issues with `unnest()` documented in #8. The test example in that issue that previously took 29.3s now takes 1.4s. 

This also addresses the warnings that were being thrown by the deprecated function `dplyr::as_data_frame()`

![Screen Shot 2020-07-23 at 12 02 56 AM](https://user-images.githubusercontent.com/5262024/88259798-e1d18280-cc77-11ea-8f3a-2872fb78526a.png)
